### PR TITLE
Fire selection events from server, keep selected tab on add/remove

### DIFF
--- a/src/test/java/com/vaadin/flow/component/tabs/tests/SelectedTabIT.java
+++ b/src/test/java/com/vaadin/flow/component/tabs/tests/SelectedTabIT.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.component.tabs.tests;
 import java.util.List;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
@@ -29,10 +30,13 @@ import com.vaadin.testbench.TestBenchElement;
 @TestPath("selected-tab")
 public class SelectedTabIT extends AbstractComponentIT {
 
+    @Before
+    public void init() {
+        open();
+    }
+
     @Test
     public void verifyTabIsSelected() {
-        open();
-
         findElement(By.id("second")).click();
         findElement(By.id("show-selection")).click();
 
@@ -51,24 +55,27 @@ public class SelectedTabIT extends AbstractComponentIT {
     }
 
     @Test
-    public void selectionEventOnItemsChange() {
-        open();
-
+    public void removeSelectedTabFromServer_changeEventFromServer() {
         findElement(By.id("delete")).click();
-
-        WebElement selectionEvent = findElement(By.id("selection-event"));
-
-        Assert.assertEquals("bar", selectionEvent.getText());
-
-        findElement(By.id("add")).click();
-
-        Assert.assertEquals("baz", selectionEvent.getText());
+        assertSelectionEvent(1, "bar server");
     }
 
     @Test
-    public void selectDisabledTab_selectionIsResetAndRedisabled() {
-        open();
+    public void selectSecondTab_eventFromClient_deleteFirstTab_noEvent() {
+        findElement(By.id("second")).click();
+        assertSelectionEvent(1, "bar client");
+        findElement(By.id("delete-first")).click();
+        assertSelectionEvent(1, "bar client");
+    }
 
+    @Test
+    public void addTabAsFirst_noEvent() {
+        findElement(By.id("add-first")).click();
+        assertSelectionEvent(0, null);
+    }
+
+    @Test
+    public void selectDisabledTab_noSelectionEvent_tabIsRedisabled() {
         List<TestBenchElement> tabs = $("vaadin-tabs").first().$("vaadin-tab")
                 .all();
         TestBenchElement lastTab = tabs.get(tabs.size() - 1);
@@ -78,10 +85,29 @@ public class SelectedTabIT extends AbstractComponentIT {
 
         lastTab.click();
 
-        WebElement selectionEvent = findElement(By.id("selection-event"));
-        Assert.assertEquals("foo", selectionEvent.getText());
+        assertSelectionEvent(0, null);
 
         Assert.assertEquals(Boolean.TRUE.toString(),
                 lastTab.getAttribute("disabled"));
+    }
+
+    private void assertSelectionEvent(int amountOfEvents,
+            String expectedLatestMessage) {
+        List<WebElement> selectionEventMessages = findElements(
+                By.className("selection-event"));
+
+        Assert.assertEquals(
+                "Unexpected amount of selection events have been fired",
+                amountOfEvents, selectionEventMessages.size());
+
+        if (amountOfEvents == 0) {
+            return;
+        }
+
+        WebElement lastMessage = selectionEventMessages
+                .get(selectionEventMessages.size() - 1);
+
+        Assert.assertEquals("Unexpected message for the latest selection event",
+                expectedLatestMessage, lastMessage.getText());
     }
 }

--- a/src/test/java/com/vaadin/flow/component/tabs/tests/SelectedTabPage.java
+++ b/src/test/java/com/vaadin/flow/component/tabs/tests/SelectedTabPage.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.component.tabs.tests;
 
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.html.Paragraph;
 import com.vaadin.flow.component.tabs.Tab;
 import com.vaadin.flow.component.tabs.Tabs;
 import com.vaadin.flow.router.Route;
@@ -54,16 +55,33 @@ public class SelectedTabPage extends Div {
                 event -> tabs.remove(tabs.getSelectedTab()));
         delete.setId("delete");
 
-        NativeButton add = new NativeButton("Add new tab as the first",
+        NativeButton addFirst = new NativeButton("Add new tab as the first",
                 event -> tabs.addComponentAsFirst(new Tab("baz")));
-        add.setId("add");
+        addFirst.setId("add-first");
 
-        Div selectedTab = new Div();
-        tabs.addSelectedChangeListener(
-                event -> selectedTab.setText(tabs.getSelectedTab().getLabel()));
+        NativeButton setSelectedIndex = new NativeButton("setSelectedIndex(1)",
+                event -> tabs.setSelectedIndex(1));
+        setSelectedIndex.setId("set-selected-index");
 
-        selectedTab.setId("selection-event");
+        NativeButton setSelectedTab = new NativeButton("setSelectedTab(tab2)",
+                event -> tabs.setSelectedTab(tab2));
+        setSelectedIndex.setId("set-selected-tab");
 
-        add(tabs, button, delete, add, selectedTab);
+        NativeButton deleteFirst = new NativeButton("Delete first tab",
+                event -> tabs.remove(tabs.getChildren().findFirst().get()));
+        deleteFirst.setId("delete-first");
+
+        tabs.addSelectedChangeListener(event -> addEventMessage(
+                tabs.getSelectedTab().getLabel(), event.isFromClient()));
+
+        add(tabs, button, delete, deleteFirst, addFirst, setSelectedIndex,
+                setSelectedTab);
+    }
+
+    private void addEventMessage(String tabLabel, boolean isFromClient) {
+        Paragraph message = new Paragraph(
+                tabLabel + (isFromClient ? " client" : " server"));
+        message.setClassName("selection-event");
+        add(message);
     }
 }

--- a/src/test/java/com/vaadin/flow/component/tabs/tests/SelectionEventTest.java
+++ b/src/test/java/com/vaadin/flow/component/tabs/tests/SelectionEventTest.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.component.tabs.tests;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.flow.component.tabs.Tab;
+import com.vaadin.flow.component.tabs.Tabs;
+
+/**
+ * @author Vaadin Ltd.
+ */
+public class SelectionEventTest {
+
+    private Tabs tabs;
+    private Tab tab1;
+    private Tab tab2;
+
+    private int eventCount;
+
+    @Before
+    public void init() {
+        tab1 = new Tab("foo");
+        tab2 = new Tab("bar");
+        tabs = new Tabs(tab1, tab2);
+
+        tabs.addSelectedChangeListener(e -> {
+            Assert.assertFalse(
+                    "isFromClient() returned true for an event fired from server",
+                    e.isFromClient());
+            eventCount++;
+        });
+
+        eventCount = 0;
+    }
+
+    @Test
+    public void changeSelectionInServerSide_eventFiredSynchronously() {
+        tabs.setSelectedTab(tab2);
+        Assert.assertEquals(
+                "Selection event should have been fired immediately after "
+                        + "changing the selection on server side.",
+                1, eventCount);
+
+        tabs.setSelectedTab(tab2);
+        Assert.assertEquals("The tab was already selected, selection event "
+                + "should not have been fired.", 1, eventCount);
+
+        tabs.setSelectedIndex(0);
+        Assert.assertEquals(
+                "Selection event should have been fired immediately after "
+                        + "changing the selection on server side.",
+                2, eventCount);
+
+        tabs.setSelectedIndex(0);
+        Assert.assertEquals("The tab was already selected, selection event "
+                + "should not have been fired.", 2, eventCount);
+    }
+
+    @Test
+    public void removeSelectedTab_selectionChanged() {
+        tabs.remove(tab1);
+        Assert.assertEquals(
+                "Selection event should have been fired after removing the selected tab",
+                1, eventCount);
+        Assert.assertEquals(
+                "The next tab should be selected after removing the selected tab",
+                tabs.getSelectedTab(), tab2);
+    }
+
+    @Test
+    public void removeLaterTab_selectionNotChanged() {
+        tabs.remove(tab2);
+        Assert.assertEquals(
+                "Selection event should not have been fired after removing the other tab",
+                0, eventCount);
+        Assert.assertEquals("The selected tab should not have been changed",
+                tabs.getSelectedTab(), tab1);
+    }
+
+    @Test
+    public void removeEarlierTab_selectionNotChanged() {
+        tabs.setSelectedTab(tab2);
+        Assert.assertEquals(1, eventCount);
+        tabs.remove(tab1);
+
+        Assert.assertEquals(
+                "Selection event should not have been fired after removing the other tab",
+                1, eventCount);
+
+        Assert.assertEquals(
+                "The selected index should have been reduced to keep the old selection",
+                0, tabs.getSelectedIndex());
+
+        Assert.assertEquals("The selected tab should not have been changed",
+                tabs.getSelectedTab(), tab2);
+    }
+
+    @Test
+    public void removeAllTabs_selectionChangedToNull_selectedIndexZero() {
+        tabs.remove(tab1, tab2);
+
+        Assert.assertEquals(
+                "Selection event should have been fired after removing all the tabs",
+                1, eventCount);
+
+        Assert.assertEquals(
+                "The selected index should be 0 when there are no tabs", 0,
+                tabs.getSelectedIndex());
+
+        Assert.assertEquals(
+                "The selected tab should be null after removing all tabs",
+                tabs.getSelectedTab(), null);
+    }
+
+    @Test
+    public void selectSecondTab_removeAll_selectionChangedToNull_selectedIndexZero() {
+        tabs.setSelectedIndex(1);
+        Assert.assertEquals(1, eventCount);
+
+        tabs.removeAll();
+
+        Assert.assertEquals(
+                "Selection event should have been fired after removing all the tabs",
+                2, eventCount);
+
+        Assert.assertEquals(
+                "The selected index should be 0 when there are no tabs", 0,
+                tabs.getSelectedIndex());
+
+        Assert.assertEquals(
+                "The selected tab should be null after removing all tabs",
+                tabs.getSelectedTab(), null);
+    }
+
+    @Test
+    public void addTabs_selectionNotChanged() {
+        tabs.addComponentAsFirst(new Tab());
+        tabs.add(new Tab());
+
+        Assert.assertEquals(
+                "Selection event should not have been fired after adding new tabs",
+                0, eventCount);
+
+        Assert.assertEquals(
+                "Selection should not have been changed after adding new tabs",
+                tab1, tabs.getSelectedTab());
+
+        Assert.assertEquals(
+                "Selected index should have been incremented after adding new tab in the beginning",
+                1, tabs.getSelectedIndex());
+    }
+
+    @Test
+    public void selectLastTab_removeLastTab_secondLastTabIsSelected() {
+        tabs.setSelectedTab(tab2);
+        Assert.assertEquals(1, eventCount);
+        tabs.remove(tab2);
+        Assert.assertEquals(
+                "Selection event should have been fired after removing the selected tab",
+                2, eventCount);
+        Assert.assertEquals(
+                "The new last tab should be selected after removing the last tab which was selected",
+                tab1, tabs.getSelectedTab());
+    }
+
+    @Test
+    public void replaceSelectedTab_eventIsFired_newTabIsSelected() {
+        Tab replaceTab = new Tab("replace");
+        tabs.replace(tab1, replaceTab);
+        Assert.assertEquals(
+                "Selection event should have been fired after replacing the selected tab",
+                1, eventCount);
+        Assert.assertEquals(
+                "After replacing the selected tab, the new tab should be selected",
+                replaceTab, tabs.getSelectedTab());
+    }
+
+    @After
+    public void checkThatOnlyOneTabIsSelected() {
+        if (tabs.getComponentCount() > 0) {
+            long selectedTabs = tabs.getChildren().map(Tab.class::cast)
+                    .filter(Tab::isSelected).count();
+            Assert.assertEquals("Exactly one of the tabs should be selected", 1,
+                    selectedTabs);
+        }
+    }
+
+}


### PR DESCRIPTION
- SelectedChangeEvent is no longer annotated with DomEvent 
- PropertyChangeListener is used internally to handle client-side events
- The event is fired synchronously from server-side when the selection happens on server-side
- Event.isFromClient() returns correct value
- Adding and removing tabs changes the selected index to not change the selected tab (event not fired)
- If the selected tab is removed, the selection is changed and event is fired