### PR TITLE
Allow unselecting all tabs (#73)

### DIFF
--- a/src/main/java/com/vaadin/flow/component/tabs/Tabs.java
+++ b/src/main/java/com/vaadin/flow/component/tabs/Tabs.java
@@ -67,6 +67,7 @@ public class Tabs extends GeneratedVaadinTabs<Tabs>
      * HORIZONTAL} orientation.
      */
     public Tabs() {
+        setSelectedIndex(-1);
         getElement().addPropertyChangeListener(SELECTED,
                 event -> updateSelectedTab(event.isUserOriginated()));
     }
@@ -90,14 +91,19 @@ public class Tabs extends GeneratedVaadinTabs<Tabs>
      *            the tabs to enclose
      */
     public void add(Tab... tabs) {
-        HasOrderedComponents.super.add(tabs);
-        updateSelectedTab(false);
+        add((Component[]) tabs);
     }
 
     @Override
     public void add(Component... components) {
+        boolean wasEmpty = getComponentCount() == 0;
         HasOrderedComponents.super.add(components);
-        updateSelectedTab(false);
+        if (wasEmpty) {
+            assert getSelectedIndex() == -1;
+            setSelectedIndex(0);
+        } else {
+            updateSelectedTab(false);
+        }
     }
 
     /**
@@ -123,6 +129,10 @@ public class Tabs extends GeneratedVaadinTabs<Tabs>
             newSelectedIndex = getComponentCount() - 1;
         }
 
+        if (getComponentCount() == 0) {
+            newSelectedIndex = -1;
+        }
+
         if (newSelectedIndex != getSelectedIndex()) {
             setSelectedIndex(newSelectedIndex);
         } else {
@@ -138,8 +148,8 @@ public class Tabs extends GeneratedVaadinTabs<Tabs>
     @Override
     public void removeAll() {
         HasOrderedComponents.super.removeAll();
-        if (getSelectedIndex() > 0) {
-            setSelectedIndex(0);
+        if (getSelectedIndex() > -1) {
+            setSelectedIndex(-1);
         } else {
             updateSelectedTab(false);
         }
@@ -190,18 +200,19 @@ public class Tabs extends GeneratedVaadinTabs<Tabs>
     /**
      * Gets the zero-based index of the currently selected tab.
      *
-     * @return the zero-based index of the selected tab
+     * @return the zero-based index of the selected tab, or -1 if none of the
+     *         tabs is selected
      */
     @Synchronize(property = SELECTED, value = "selected-changed")
     public int getSelectedIndex() {
-        return getElement().getProperty(SELECTED, 0);
+        return getElement().getProperty(SELECTED, -1);
     }
 
     /**
      * Selects a tab based on its zero-based index.
      *
      * @param selectedIndex
-     *            the zero-based index of the selected tab
+     *            the zero-based index of the selected tab, -1 to unselect all
      */
     public void setSelectedIndex(int selectedIndex) {
         getElement().setProperty(SELECTED, selectedIndex);
@@ -210,15 +221,14 @@ public class Tabs extends GeneratedVaadinTabs<Tabs>
     /**
      * Gets the currently selected tab.
      *
-     * @return the selected tab
+     * @return the selected tab, or {@code null} if none is selected
      */
     public Tab getSelectedTab() {
-        if (getChildren().count() == 0) {
-            assert getSelectedIndex() == 0;
+        int selectedIndex = getSelectedIndex();
+        if (selectedIndex < 0) {
             return null;
         }
 
-        int selectedIndex = getSelectedIndex();
         Component selectedComponent = getComponentAt(selectedIndex);
         if (!(selectedComponent instanceof Tab)) {
             throw new IllegalStateException(
@@ -231,17 +241,22 @@ public class Tabs extends GeneratedVaadinTabs<Tabs>
      * Selects the given tab.
      *
      * @param selectedTab
-     *            the tab to select
+     *            the tab to select, {@code null} to unselect all
      * @throws IllegalArgumentException
      *             if {@code selectedTab} is not a child of this component
      */
     public void setSelectedTab(Tab selectedTab) {
+        if (selectedTab == null) {
+            setSelectedIndex(-1);
+            return;
+        }
+
         int selectedIndex = indexOf(selectedTab);
         if (selectedIndex < 0) {
             throw new IllegalArgumentException(
                     "Tab to select must be a child: " + selectedTab);
         }
-        getElement().setProperty(SELECTED, selectedIndex);
+        setSelectedIndex(selectedIndex);
     }
 
     /**
@@ -298,22 +313,25 @@ public class Tabs extends GeneratedVaadinTabs<Tabs>
 
     @ClientCallable
     private void updateSelectedTab(boolean changedFromClient) {
+        if (getSelectedIndex() < -1) {
+            setSelectedIndex(-1);
+            return;
+        }
+
         Tab currentlySelected = getSelectedTab();
 
         if (Objects.equals(currentlySelected, selectedTab)) {
             return;
         }
 
-        if (currentlySelected == null) {
-            fireEvent(new SelectedChangeEvent(this, changedFromClient));
-            return;
-        }
-
-        if (currentlySelected.isEnabled()) {
+        if (currentlySelected == null || currentlySelected.isEnabled()) {
             selectedTab = currentlySelected;
             getChildren().filter(Tab.class::isInstance).map(Tab.class::cast)
                     .forEach(tab -> tab.setSelected(false));
-            selectedTab.setSelected(true);
+
+            if (selectedTab != null) {
+                selectedTab.setSelected(true);
+            }
 
             fireEvent(new SelectedChangeEvent(this, changedFromClient));
         } else {

--- a/src/test/java/com/vaadin/flow/component/tabs/tests/SelectedTabIT.java
+++ b/src/test/java/com/vaadin/flow/component/tabs/tests/SelectedTabIT.java
@@ -91,6 +91,27 @@ public class SelectedTabIT extends AbstractComponentIT {
         assertSelectionEvent(1, "asdf client");
     }
 
+    @Test
+    public void testUnselectingAndReselecting() {
+        List<TestBenchElement> tabs = $("vaadin-tabs").first().$("vaadin-tab")
+                .all();
+
+        clickElementWithJs("unselect");
+        assertSelectionEvent(1, "null server");
+
+        tabs.get(0).click();
+        assertSelectionEvent(2, "foo client");
+
+        clickElementWithJs("unselect-with-index");
+        assertSelectionEvent(3, "null server");
+
+        clickElementWithJs("unselect");
+        assertSelectionEvent(3, "null server"); // no event
+
+        clickElementWithJs("set-selected-tab");
+        assertSelectionEvent(4, "bar server");
+    }
+
     private void assertSelectionEvent(int amountOfEvents,
             String expectedLatestMessage) {
         List<WebElement> selectionEventMessages = findElements(

--- a/src/test/java/com/vaadin/flow/component/tabs/tests/SelectedTabPage.java
+++ b/src/test/java/com/vaadin/flow/component/tabs/tests/SelectedTabPage.java
@@ -74,10 +74,20 @@ public class SelectedTabPage extends Div {
         addFirstWithElementAPI.setId("add-first-with-element-api");
 
         tabs.addSelectedChangeListener(event -> addEventMessage(
-                tabs.getSelectedTab().getLabel(), event.isFromClient()));
+                tabs.getSelectedTab() == null ? "null"
+                        : tabs.getSelectedTab().getLabel(),
+                event.isFromClient()));
+
+        NativeButton unselect = new NativeButton("Unselect",
+                event -> tabs.setSelectedTab(null));
+        unselect.setId("unselect");
+
+        NativeButton unselectWithIndex = new NativeButton("Unselect with index",
+                event -> tabs.setSelectedIndex(-1));
+        unselectWithIndex.setId("unselect-with-index");
 
         add(tabs, button, delete, deleteFirst, addFirstWithElementAPI,
-                setSelectedIndex, setSelectedTab);
+                setSelectedIndex, setSelectedTab, unselect, unselectWithIndex);
     }
 
     private void addEventMessage(String tabLabel, boolean isFromClient) {

--- a/src/test/java/com/vaadin/flow/component/tabs/tests/SelectionEventTest.java
+++ b/src/test/java/com/vaadin/flow/component/tabs/tests/SelectionEventTest.java
@@ -16,7 +16,6 @@
 
 package com.vaadin.flow.component.tabs.tests;
 
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -114,7 +113,7 @@ public class SelectionEventTest {
     }
 
     @Test
-    public void removeAllTabs_selectionChangedToNull_selectedIndexZero() {
+    public void removeAllTabs_selectionChangedToNull_selectedIndexMinusOne() {
         tabs.remove(tab1, tab2);
 
         Assert.assertEquals(
@@ -122,7 +121,7 @@ public class SelectionEventTest {
                 1, eventCount);
 
         Assert.assertEquals(
-                "The selected index should be 0 when there are no tabs", 0,
+                "The selected index should be -1 when there are no tabs", -1,
                 tabs.getSelectedIndex());
 
         Assert.assertEquals(
@@ -131,7 +130,7 @@ public class SelectionEventTest {
     }
 
     @Test
-    public void selectSecondTab_removeAll_selectionChangedToNull_selectedIndexZero() {
+    public void selectSecondTab_removeAll_selectionChangedToNull_selectedIndexMinusOne() {
         tabs.setSelectedIndex(1);
         Assert.assertEquals(1, eventCount);
 
@@ -142,7 +141,7 @@ public class SelectionEventTest {
                 2, eventCount);
 
         Assert.assertEquals(
-                "The selected index should be 0 when there are no tabs", 0,
+                "The selected index should be -1 when there are no tabs", -1,
                 tabs.getSelectedIndex());
 
         Assert.assertEquals(
@@ -175,14 +174,77 @@ public class SelectionEventTest {
                 replaceTab, tabs.getSelectedTab());
     }
 
-    @After
-    public void checkThatOnlyOneTabIsSelected() {
-        if (tabs.getComponentCount() > 0) {
-            long selectedTabs = tabs.getChildren().map(Tab.class::cast)
-                    .filter(Tab::isSelected).count();
-            Assert.assertEquals("Exactly one of the tabs should be selected", 1,
-                    selectedTabs);
-        }
+    @Test
+    public void removeNonChildTab_selectionNotChanged() {
+        tabs.setSelectedTab(tab2);
+        Assert.assertEquals(1, eventCount);
+        Tab orphan = new Tab();
+        tabs.remove(orphan);
+        Assert.assertEquals(
+                "Selection event should not have been fired after "
+                        + "removing a Tab which is not a child of the Tabs.",
+                1, eventCount);
+        Assert.assertEquals(
+                "Selected tab should not have been changed after "
+                        + "removing a Tab which is not a child of the Tabs.",
+                tab2, tabs.getSelectedTab());
+    }
+
+    @Test
+    public void unselect_eventFired_selectedIndexMinusOne() {
+        tabs.setSelectedTab(null);
+        Assert.assertEquals("Unselecting the selected tab should fire event", 1,
+                eventCount);
+        Assert.assertEquals("The selected tab should be null after unselecting",
+                null, tabs.getSelectedTab());
+        Assert.assertEquals("The selected index is -1 when no tab is selected",
+                -1, tabs.getSelectedIndex());
+    }
+
+    @Test
+    public void unselectWithIndex() {
+        tabs.setSelectedIndex(-1);
+        Assert.assertEquals("Unselecting the selected tab should fire event", 1,
+                eventCount);
+        Assert.assertEquals("The selected tab should be null after unselecting",
+                null, tabs.getSelectedTab());
+    }
+
+    @Test
+    public void unselectWithAnyNegativeIndex_selectedIndexMinusOne() {
+        tabs.setSelectedIndex(-100);
+        Assert.assertEquals("Unselecting the selected tab should fire event", 1,
+                eventCount);
+        Assert.assertEquals("The selected tab should be null after unselecting",
+                null, tabs.getSelectedTab());
+        Assert.assertEquals(
+                "The selected index should return -1 when no tab is selected, even "
+                        + "when the index was set as some other negative number",
+                -1, tabs.getSelectedIndex());
+    }
+
+    @Test
+    public void unselect_selectOldSelection_eventFired() {
+        tabs.setSelectedTab(null);
+        tabs.setSelectedTab(tab1);
+        Assert.assertEquals("Selection event should have been fired", 2,
+                eventCount);
+        Assert.assertEquals("Selected tab should be the one which was selected",
+                tab1, tabs.getSelectedTab());
+    }
+
+    @Test
+    public void unselectMultipleTimes_noEvent() {
+        tabs.setSelectedTab(null);
+        Assert.assertEquals(1, eventCount);
+        tabs.setSelectedTab(null);
+        Assert.assertEquals(
+                "Selection was not changed, no event should've been fired", 1,
+                eventCount);
+        tabs.setSelectedIndex(-1);
+        Assert.assertEquals(
+                "Selection was not changed, no event should've been fired", 1,
+                eventCount);
     }
 
 }

--- a/src/test/java/com/vaadin/flow/component/tabs/tests/TabsTest.java
+++ b/src/test/java/com/vaadin/flow/component/tabs/tests/TabsTest.java
@@ -19,6 +19,7 @@ package com.vaadin.flow.component.tabs.tests;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
+import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -43,6 +44,10 @@ public class TabsTest {
                 is(0));
         assertThat("Initial orientation is invalid", tabs.getOrientation(),
                 is(Tabs.Orientation.HORIZONTAL));
+        assertThat("Initial selected index is invalid", tabs.getSelectedIndex(),
+                is(-1));
+        assertThat("Initial child count is invalid", tabs.getSelectedTab(),
+                CoreMatchers.nullValue());
     }
 
     @Test


### PR DESCRIPTION
* Allow unselecting all tabs

either with setSelectedTab(null) or setSelectedIndex(-1)

Fixes #72
Fixes #70

* Avoid duplicating add-logic

* Allow unselecting with any negative index