### PR TITLE
Add option to turn off first tab auto selection. (#76)

### DIFF
--- a/vaadin-tabs-flow-demo/src/main/java/com/vaadin/flow/component/tabs/demo/TabsView.java
+++ b/vaadin-tabs-flow-demo/src/main/java/com/vaadin/flow/component/tabs/demo/TabsView.java
@@ -23,6 +23,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Text;
 import com.vaadin.flow.component.checkbox.Checkbox;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Image;
@@ -57,6 +58,7 @@ public class TabsView extends DemoView {
         createTabsWithPages();
         createTabsWithCustomContent();
         createTebsWithThemeVariants();
+        createTabsAutoselectFalse();
     }
 
     private void createTebsWithThemeVariants() {
@@ -68,7 +70,7 @@ public class TabsView extends DemoView {
         Tabs tabs = new Tabs(tab1, tab2, tab3);
         tabs.addThemeVariants(TabsVariant.LUMO_SMALL);
         // end-source-example
-        
+
         addVariantsDemo(() -> {
             return tabs;
         }, GeneratedVaadinTabs::addThemeVariants,
@@ -247,5 +249,31 @@ public class TabsView extends DemoView {
 
         tabs.setId("tabs-with-custom-content");
         addCard("Tabs with custom content", tabs);
+    }
+
+    private void createTabsAutoselectFalse() {
+        // begin-source-example
+        // source-example-heading: Tabs with automatic select set to false
+        Tab tab1 = new Tab("Tab one");
+        Tab tab2 = new Tab("Tab two");
+        Tab tab3 = new Tab("Tab three");
+        Tabs tabs = new Tabs();
+        tabs.setAutoselect(false);
+        tabs.add(tab1, tab2, tab3);
+
+        Text newText = new Text("");
+        Text oldText = new Text("");
+        tabs.addSelectedChangeListener(event -> {
+            newText.setText("Current tab : " + event.getSelectedTab().getLabel());
+
+            if (event.getPreviousTab() != null) {
+                oldText.setText(
+                        "Previous tab : " + event.getPreviousTab().getLabel());
+            }
+        });
+        // end-source-example
+
+        tabs.setId("tabs-auto-select-false");
+        addCard("Tabs with automatic select set to false", tabs, newText, oldText);
     }
 }

--- a/vaadin-tabs-flow-demo/src/main/java/com/vaadin/flow/component/tabs/demo/TabsView.java
+++ b/vaadin-tabs-flow-demo/src/main/java/com/vaadin/flow/component/tabs/demo/TabsView.java
@@ -257,9 +257,7 @@ public class TabsView extends DemoView {
         Tab tab1 = new Tab("Tab one");
         Tab tab2 = new Tab("Tab two");
         Tab tab3 = new Tab("Tab three");
-        Tabs tabs = new Tabs();
-        tabs.setAutoselect(false);
-        tabs.add(tab1, tab2, tab3);
+        Tabs tabs = new Tabs(false, tab1, tab2, tab3);
 
         Text newText = new Text("");
         Text oldText = new Text("");

--- a/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/Tabs.java
+++ b/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/Tabs.java
@@ -55,6 +55,8 @@ public class Tabs extends GeneratedVaadinTabs<Tabs>
 
     private transient Tab selectedTab;
 
+    private boolean autoselect = true;
+
     /**
      * The valid orientations of {@link Tabs} instances.
      */
@@ -85,6 +87,21 @@ public class Tabs extends GeneratedVaadinTabs<Tabs>
     }
 
     /**
+     * Constructs a new object enclosing the given autoselect option and tabs, with
+     * {@link Orientation#HORIZONTAL HORIZONTAL} orientation.
+     *
+     * @param autoselect
+     *            @{code true} to autoselect tab, {@code false} to not
+     * @param tabs
+     *            the tabs to enclose
+     */
+    public Tabs(boolean autoselect, Tab... tabs) {
+        this();
+        this.autoselect = autoselect;
+        add(tabs);
+    }
+
+    /**
      * Adds the given tabs to the component.
      *
      * @param tabs
@@ -98,7 +115,7 @@ public class Tabs extends GeneratedVaadinTabs<Tabs>
     public void add(Component... components) {
         boolean wasEmpty = getComponentCount() == 0;
         HasOrderedComponents.super.add(components);
-        if (wasEmpty) {
+        if (wasEmpty && autoselect) {
             assert getSelectedIndex() == -1;
             setSelectedIndex(0);
         } else {
@@ -129,7 +146,7 @@ public class Tabs extends GeneratedVaadinTabs<Tabs>
             newSelectedIndex = getComponentCount() - 1;
         }
 
-        if (getComponentCount() == 0) {
+        if (getComponentCount() == 0 || !isAutoselect()) {
             newSelectedIndex = -1;
         }
 
@@ -187,8 +204,74 @@ public class Tabs extends GeneratedVaadinTabs<Tabs>
      * An event to mark that the selected tab has changed.
      */
     public static class SelectedChangeEvent extends ComponentEvent<Tabs> {
+        private final Tab selectedTab;
+        private final Tab previousTab;
+        private final boolean initialSelection;
+
+        /**
+         * Creates a new selected change event.
+         *
+         * @param source
+         *            The tabs that fired the event.
+         * @param fromClient
+         *            <code>true</code> for client-side events, <code>false</code>
+         *            otherwise.
+         *
+         * @deprecated use {@link #SelectedChangeEvent(Tabs source, Tab previousTab, boolean fromClient)} instead.
+         */
+        @Deprecated
         public SelectedChangeEvent(Tabs source, boolean fromClient) {
+            this(source, null, fromClient);
+        }
+
+        /**
+         * Creates a new selected change event.
+         *
+         * @param source
+         *            The tabs that fired the event.
+         * @param previousTab
+         *            The previous selected tab.
+         * @param fromClient
+         *            <code>true</code> for client-side events, <code>false</code>
+         *            otherwise.
+         */
+        public SelectedChangeEvent(Tabs source, Tab previousTab, boolean fromClient) {
             super(source, fromClient);
+            this.selectedTab = source.getSelectedTab();
+            this.initialSelection = source.isAutoselect() &&
+                    previousTab == null &&
+                    !fromClient;
+            this.previousTab = previousTab;
+        }
+
+        /**
+         * Get selected tab for this event.
+         * Can be {@code null} when autoselect is set to false.
+         *
+         * @return the selected tab for this event
+         */
+        public Tab getSelectedTab() {
+            return this.selectedTab;
+        }
+
+        /**
+         * Get previous selected tab for this event.
+         * Can be {@code null} when autoselect is set to false.
+         *
+         * @return the selected tab for this event
+         */
+        public Tab getPreviousTab() {
+            return this.previousTab;
+        }
+
+        /**
+         * Checks if this event is initial tabs selection.
+         *
+         * @return <code>true</code> if the event is initial tabs selection,
+         *         <code>false</code> otherwise
+         */
+        public boolean isInitialSelection() {
+            return this.initialSelection;
         }
     }
 
@@ -204,7 +287,7 @@ public class Tabs extends GeneratedVaadinTabs<Tabs>
 
     /**
      * Adds a listener for {@link SelectedChangeEvent}.
-     * 
+     *
      * @param listener
      *            the listener to add, not <code>null</code>
      * @return a handle that can be used for removing the listener
@@ -328,6 +411,31 @@ public class Tabs extends GeneratedVaadinTabs<Tabs>
         getChildren().forEach(tab -> ((Tab) tab).setFlexGrow(flexGrow));
     }
 
+    /**
+     * Specify that the tabs should be automatically selected.
+     * When autoselect is false, no tab will be selected when the component load
+     * and it will not select any others tab when removing currently selected tab.
+     * The default value is true.
+     *
+     * @param autoselect
+     *            @{code true} to autoselect tab, {@code false} to not.
+     */
+    public void setAutoselect(boolean autoselect) {
+        this.autoselect = autoselect;
+    }
+
+    /**
+     * Gets whether the tabs should be automatically selected.
+     * The default value is true.
+     *
+     * @return <code>true</code> if autoselect is active, <code>false</code>
+     *         otherwise
+     * @see #setAutoselect(boolean)
+     */
+    public boolean isAutoselect() {
+        return this.autoselect;
+    }
+
     @ClientCallable
     private void updateSelectedTab(boolean changedFromClient) {
         if (getSelectedIndex() < -1) {
@@ -336,6 +444,7 @@ public class Tabs extends GeneratedVaadinTabs<Tabs>
         }
 
         Tab currentlySelected = getSelectedTab();
+        Tab previousTab = selectedTab;
 
         if (Objects.equals(currentlySelected, selectedTab)) {
             return;
@@ -350,7 +459,7 @@ public class Tabs extends GeneratedVaadinTabs<Tabs>
                 selectedTab.setSelected(true);
             }
 
-            fireEvent(new SelectedChangeEvent(this, changedFromClient));
+            fireEvent(new SelectedChangeEvent(this, previousTab, changedFromClient));
         } else {
             updateEnabled(currentlySelected);
             setSelectedTab(selectedTab);

--- a/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/Tabs.java
+++ b/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/Tabs.java
@@ -128,13 +128,17 @@ public class Tabs extends GeneratedVaadinTabs<Tabs>
      * <p>
      * Removing components before the selected tab will decrease the
      * {@link #getSelectedIndex() selected index} to avoid changing the selected
-     * tab. Removing the selected tab will select the next available tab.
+     * tab. Removing the selected tab will select the next available tab if autoselect is true,
+     * otherwise no tab will be selected.
      */
     @Override
     public void remove(Component... components) {
         int lowerIndices = (int) Stream.of(components).map(this::indexOf)
                 .filter(index -> index >= 0 && index < getSelectedIndex())
                 .count();
+
+        boolean isSelectedTab = Stream.of(components)
+                .anyMatch(component -> component.equals(getSelectedTab()));
 
         HasOrderedComponents.super.remove(components);
 
@@ -146,7 +150,7 @@ public class Tabs extends GeneratedVaadinTabs<Tabs>
             newSelectedIndex = getComponentCount() - 1;
         }
 
-        if (getComponentCount() == 0 || !isAutoselect()) {
+        if (getComponentCount() == 0 || (isSelectedTab && !isAutoselect())) {
             newSelectedIndex = -1;
         }
 

--- a/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/SelectionEventTest.java
+++ b/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/SelectionEventTest.java
@@ -16,12 +16,13 @@
 
 package com.vaadin.flow.component.tabs.tests;
 
+import com.vaadin.flow.component.tabs.Tab;
+import com.vaadin.flow.component.tabs.Tabs;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.vaadin.flow.component.tabs.Tab;
-import com.vaadin.flow.component.tabs.Tabs;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * @author Vaadin Ltd.
@@ -263,6 +264,37 @@ public class SelectionEventTest {
         Assert.assertEquals(
                 "Selection was not changed, no event should've been fired", 1,
                 eventCount);
+    }
+
+    @Test
+    public void tabsAutoselectFalse_previousAndCurrentTab() {
+        AtomicReference<Tab> currentTab = new AtomicReference<>();
+        AtomicReference<Tab> previousTab = new AtomicReference<>();
+        tabs = new Tabs();
+        tabs.setAutoselect(false);
+        tabs.add(tab1, tab2);
+        tabs.addSelectedChangeListener(e -> {
+            currentTab.set(e.getSelectedTab());
+            previousTab.set(e.getPreviousTab());
+        });
+
+        tabs.setSelectedTab(tab1);
+        Assert.assertEquals("Current tab should be tab 1", currentTab.get(), tab1);
+        Assert.assertNull("Previous tab should be empty", previousTab.get());
+
+        tabs.setSelectedTab(tab2);
+        Assert.assertEquals("Current tab should be tab 2", currentTab.get(), tab2);
+        Assert.assertEquals("Previous tab should be tab 1", previousTab.get(), tab1);
+    }
+
+    @Test
+    public void removeCurrent_withoutAutomaticSelectionResetsSelection() {
+        tabs.setAutoselect(false);
+        tabs.setSelectedIndex(1);
+        Assert.assertEquals(tab2, tabs.getSelectedTab());
+
+        tabs.remove(tab2);
+        Assert.assertEquals(tabs.getSelectedIndex(), -1);
     }
 
 }

--- a/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/TabsTest.java
+++ b/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/TabsTest.java
@@ -154,4 +154,14 @@ public class TabsTest {
         Assert.assertFalse(tab1.isSelected());
         Assert.assertTrue(tab2.isSelected());
     }
+
+    @Test
+    public void tabsWithoutAutomaticSelection() {
+        Tab tab1 = new Tab("Tab one");
+        Tab tab2 = new Tab("Tab two");
+        Tabs tabs = new Tabs(false, tab1, tab2);
+
+        Assert.assertNull(tabs.getSelectedTab());
+        Assert.assertEquals(tabs.getSelectedIndex(), -1);
+    }
 }

--- a/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/TabsTest.java
+++ b/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/TabsTest.java
@@ -164,4 +164,22 @@ public class TabsTest {
         Assert.assertNull(tabs.getSelectedTab());
         Assert.assertEquals(tabs.getSelectedIndex(), -1);
     }
+
+    @Test
+    public void removeTabInTabsWithoutAutomaticSelection() {
+        Tab tab1 = new Tab("Tab one");
+        Tab tab2 = new Tab("Tab two");
+        Tab tab3 = new Tab("Tab three");
+        Tabs tabs = new Tabs(false, tab1, tab2, tab3);
+
+        tabs.setSelectedTab(tab2);
+        tabs.remove(tab1);
+
+        Assert.assertEquals("should not change selected tab",
+                tabs.getSelectedTab(), tab2);
+
+        tabs.remove(tab2);
+        Assert.assertNull("should not select other tab if current tab removed",
+                tabs.getSelectedTab());
+    }
 }


### PR DESCRIPTION
Fixes #76 

Add option to turn off auto selection. `setAutoSelect(boolean)`.

add data to the `SelectedChangedEvent`
`Tab getSelectedTab()`
`Tab getPreviousTab()`
`boolean isInitialSelection()`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-tabs-flow/83)
<!-- Reviewable:end -->
