### PR TITLE
Fix autoselect on addComponentAtIndex, improve JavaDocs

### DIFF
--- a/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/Tabs.java
+++ b/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/Tabs.java
@@ -100,7 +100,7 @@ public class Tabs extends GeneratedVaadinTabs<Tabs>
      *
      * @param autoselect
      *            {@code true} to automatically select the first added tab,
-     *            {@code false} to not
+     *            {@code false} to leave tabs unselected
      * @param tabs
      *            the tabs to enclose
      */

--- a/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/Tabs.java
+++ b/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/Tabs.java
@@ -29,7 +29,6 @@ import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.component.HasOrderedComponents;
 import com.vaadin.flow.component.HasSize;
 import com.vaadin.flow.component.Synchronize;
-import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.shared.Registration;
 
 /**
@@ -88,8 +87,8 @@ public class Tabs extends GeneratedVaadinTabs<Tabs>
     }
 
     /**
-     * Constructs a new object enclosing the given autoselect option and tabs, with
-     * {@link Orientation#HORIZONTAL HORIZONTAL} orientation.
+     * Constructs a new object enclosing the given autoselect option and tabs,
+     * with {@link Orientation#HORIZONTAL HORIZONTAL} orientation.
      *
      * @param autoselect
      *            {@code true} to autoselect tab, {@code false} to not
@@ -132,8 +131,8 @@ public class Tabs extends GeneratedVaadinTabs<Tabs>
      * <p>
      * Removing components before the selected tab will decrease the
      * {@link #getSelectedIndex() selected index} to avoid changing the selected
-     * tab. Removing the selected tab will select the next available tab if autoselect is true,
-     * otherwise no tab will be selected.
+     * tab. Removing the selected tab will select the next available tab if
+     * autoselect is true, otherwise no tab will be selected.
      */
     @Override
     public void remove(Component... components) {
@@ -191,7 +190,9 @@ public class Tabs extends GeneratedVaadinTabs<Tabs>
     public void addComponentAtIndex(int index, Component component) {
         HasOrderedComponents.super.addComponentAtIndex(index, component);
 
-        if (index <= getSelectedIndex()) {
+        if (autoselect && getChildren().count() == 1) {
+            setSelectedIndex(0);
+        } else if (index <= getSelectedIndex()) {
             // Prevents changing the selected tab
             setSelectedIndex(getSelectedIndex() + 1);
         }
@@ -222,10 +223,12 @@ public class Tabs extends GeneratedVaadinTabs<Tabs>
          * @param source
          *            The tabs that fired the event.
          * @param fromClient
-         *            <code>true</code> for client-side events, <code>false</code>
-         *            otherwise.
+         *            <code>true</code> for client-side events,
+         *            <code>false</code> otherwise.
          *
-         * @deprecated use {@link #SelectedChangeEvent(Tabs source, Tab previousTab, boolean fromClient)} instead.
+         * @deprecated use
+         *             {@link #SelectedChangeEvent(Tabs source, Tab previousTab, boolean fromClient)}
+         *             instead.
          */
         @Deprecated
         public SelectedChangeEvent(Tabs source, boolean fromClient) {
@@ -240,21 +243,21 @@ public class Tabs extends GeneratedVaadinTabs<Tabs>
          * @param previousTab
          *            The previous selected tab.
          * @param fromClient
-         *            <code>true</code> for client-side events, <code>false</code>
-         *            otherwise.
+         *            <code>true</code> for client-side events,
+         *            <code>false</code> otherwise.
          */
-        public SelectedChangeEvent(Tabs source, Tab previousTab, boolean fromClient) {
+        public SelectedChangeEvent(Tabs source, Tab previousTab,
+                boolean fromClient) {
             super(source, fromClient);
             this.selectedTab = source.getSelectedTab();
-            this.initialSelection = source.isAutoselect() &&
-                    previousTab == null &&
-                    !fromClient;
+            this.initialSelection = source.isAutoselect() && previousTab == null
+                    && !fromClient;
             this.previousTab = previousTab;
         }
 
         /**
-         * Get selected tab for this event.
-         * Can be {@code null} when autoselect is set to false.
+         * Get selected tab for this event. Can be {@code null} when autoselect
+         * is set to false.
          *
          * @return the selected tab for this event
          */
@@ -263,8 +266,8 @@ public class Tabs extends GeneratedVaadinTabs<Tabs>
         }
 
         /**
-         * Get previous selected tab for this event.
-         * Can be {@code null} when autoselect is set to false.
+         * Get previous selected tab for this event. Can be {@code null} when
+         * autoselect is set to false.
          *
          * @return the selected tab for this event
          */
@@ -420,10 +423,10 @@ public class Tabs extends GeneratedVaadinTabs<Tabs>
     }
 
     /**
-     * Specify that the tabs should be automatically selected.
-     * When autoselect is false, no tab will be selected when the component load
-     * and it will not select any others tab when removing currently selected tab.
-     * The default value is true.
+     * Specify that the tabs should be automatically selected. When autoselect
+     * is false, no tab will be selected when the component load and it will not
+     * select any others tab when removing currently selected tab. The default
+     * value is true.
      *
      * @param autoselect
      *            {@code true} to autoselect tab, {@code false} to not.
@@ -433,8 +436,8 @@ public class Tabs extends GeneratedVaadinTabs<Tabs>
     }
 
     /**
-     * Gets whether the tabs should be automatically selected.
-     * The default value is true.
+     * Gets whether the tabs should be automatically selected. The default value
+     * is true.
      *
      * @return <code>true</code> if autoselect is active, <code>false</code>
      *         otherwise
@@ -467,7 +470,8 @@ public class Tabs extends GeneratedVaadinTabs<Tabs>
                 selectedTab.setSelected(true);
             }
 
-            fireEvent(new SelectedChangeEvent(this, previousTab, changedFromClient));
+            fireEvent(new SelectedChangeEvent(this, previousTab,
+                    changedFromClient));
         } else {
             updateEnabled(currentlySelected);
             setSelectedTab(selectedTab);

--- a/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/Tabs.java
+++ b/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/Tabs.java
@@ -37,9 +37,12 @@ import com.vaadin.flow.shared.Registration;
  * {@link Tab} components can be added to this component with the
  * {@link #add(Tab...)} method or the {@link #Tabs(Tab...)} constructor. The Tab
  * components added to it can be selected with the
- * {@link #setSelectedIndex(int)} or {@link #setSelectedTab(Tab)} methods.
- * Removing the selected tab from the component changes the selection to the
- * next available tab.
+ * {@link #setSelectedIndex(int)} or {@link #setSelectedTab(Tab)} methods. The
+ * first added {@link Tab} component will be automatically selected, firing a
+ * {@link SelectedChangeEvent}, unless autoselection is explicitly disabled with
+ * {@link #Tabs(boolean, Tab...)}, or {@link #setAutoselect(boolean)}. Removing
+ * the selected tab from the component changes the selection to the next
+ * available tab.
  * <p>
  * <strong>Note:</strong> Adding or removing Tab components via the Element API,
  * eg. {@code tabs.getElement().insertChild(0, tab.getElement()); }, doesn't
@@ -77,6 +80,11 @@ public class Tabs extends GeneratedVaadinTabs<Tabs>
     /**
      * Constructs a new object enclosing the given tabs, with
      * {@link Orientation#HORIZONTAL HORIZONTAL} orientation.
+     * <p>
+     * The first added {@link Tab} component will be automatically selected,
+     * firing a {@link SelectedChangeEvent}, unless autoselection is explicitly
+     * disabled with {@link #Tabs(boolean, Tab...)}, or
+     * {@link #setAutoselect(boolean)}.
      *
      * @param tabs
      *            the tabs to enclose
@@ -91,7 +99,8 @@ public class Tabs extends GeneratedVaadinTabs<Tabs>
      * with {@link Orientation#HORIZONTAL HORIZONTAL} orientation.
      *
      * @param autoselect
-     *            {@code true} to autoselect tab, {@code false} to not
+     *            {@code true} to automatically select the first added tab,
+     *            {@code false} to not
      * @param tabs
      *            the tabs to enclose
      */
@@ -103,6 +112,11 @@ public class Tabs extends GeneratedVaadinTabs<Tabs>
 
     /**
      * Adds the given tabs to the component.
+     * <p>
+     * The first added {@link Tab} component will be automatically selected,
+     * firing a {@link SelectedChangeEvent}, unless autoselection is explicitly
+     * disabled with {@link #Tabs(boolean, Tab...)}, or
+     * {@link #setAutoselect(boolean)}.
      *
      * @param tabs
      *            the tabs to enclose

--- a/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/SelectionEventTest.java
+++ b/vaadin-tabs-flow/src/test/java/com/vaadin/flow/component/tabs/tests/SelectionEventTest.java
@@ -16,13 +16,14 @@
 
 package com.vaadin.flow.component.tabs.tests;
 
-import com.vaadin.flow.component.tabs.Tab;
-import com.vaadin.flow.component.tabs.Tabs;
+import java.util.concurrent.atomic.AtomicReference;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.concurrent.atomic.AtomicReference;
+import com.vaadin.flow.component.tabs.Tab;
+import com.vaadin.flow.component.tabs.Tabs;
 
 /**
  * @author Vaadin Ltd.
@@ -41,14 +42,18 @@ public class SelectionEventTest {
         tab2 = new Tab("bar");
         tabs = new Tabs(tab1, tab2);
 
+        addSelectedChangeListener(tabs);
+
+        eventCount = 0;
+    }
+
+    private void addSelectedChangeListener(Tabs tabs) {
         tabs.addSelectedChangeListener(e -> {
             Assert.assertFalse(
                     "isFromClient() returned true for an event fired from server",
                     e.isFromClient());
             eventCount++;
         });
-
-        eventCount = 0;
     }
 
     @Test
@@ -279,12 +284,15 @@ public class SelectionEventTest {
         });
 
         tabs.setSelectedTab(tab1);
-        Assert.assertEquals("Current tab should be tab 1", currentTab.get(), tab1);
+        Assert.assertEquals("Current tab should be tab 1", currentTab.get(),
+                tab1);
         Assert.assertNull("Previous tab should be empty", previousTab.get());
 
         tabs.setSelectedTab(tab2);
-        Assert.assertEquals("Current tab should be tab 2", currentTab.get(), tab2);
-        Assert.assertEquals("Previous tab should be tab 1", previousTab.get(), tab1);
+        Assert.assertEquals("Current tab should be tab 2", currentTab.get(),
+                tab2);
+        Assert.assertEquals("Previous tab should be tab 1", previousTab.get(),
+                tab1);
     }
 
     @Test
@@ -295,6 +303,58 @@ public class SelectionEventTest {
 
         tabs.remove(tab2);
         Assert.assertEquals(tabs.getSelectedIndex(), -1);
+    }
+
+    @Test
+    public void addFirstTabWithAddComponentAtIndex_firstTabAutoselected() {
+        tabs = new Tabs();
+        addSelectedChangeListener(tabs);
+
+        tabs.addComponentAtIndex(0, tab1);
+
+        Assert.assertEquals(
+                "Unexpected selected index after adding the first tab.", 0,
+                tabs.getSelectedIndex());
+        Assert.assertEquals(
+                "Expected the first added tab to be automatically selected.",
+                tab1, tabs.getSelectedTab());
+        Assert.assertEquals("Expected autoselection to fire an event.", 1,
+                eventCount);
+    }
+
+    @Test
+    public void addSecondTabWithAddComponentAtIndex_selectionNotChanged() {
+        tabs = new Tabs();
+        addSelectedChangeListener(tabs);
+
+        tabs.addComponentAtIndex(0, tab1);
+        tabs.addComponentAtIndex(0, tab2);
+
+        Assert.assertEquals(
+                "Unexpected selected index after adding the first tab.", 1,
+                tabs.getSelectedIndex());
+        Assert.assertEquals(
+                "Expected the first added tab to be automatically selected.",
+                tab1, tabs.getSelectedTab());
+        Assert.assertEquals(
+                "Expected no selection event after adding the second tab.", 1,
+                eventCount);
+    }
+
+    @Test
+    public void disableAutoSelect_addFirstTabWithAddComponentAtIndex_noAutoselect() {
+        tabs = new Tabs(false);
+        addSelectedChangeListener(tabs);
+
+        tabs.addComponentAtIndex(0, tab1);
+
+        Assert.assertEquals(
+                "Unexpected selected index after adding the first tab.", -1,
+                tabs.getSelectedIndex());
+        Assert.assertNull("Expected no tab to be automatically selected.",
+                tabs.getSelectedTab());
+        Assert.assertEquals("Expected no selection event fired.", 0,
+                eventCount);
     }
 
 }


### PR DESCRIPTION
The first commit contains a lot of auto-formatting. The actual JavaDoc changes are in the second commit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-tabs-flow/108)
<!-- Reviewable:end -->
