### PR TITLE
Inherit implementations for setEnabled and isEnabled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,6 @@ error-screenshots/
 *.iml
 
 # The following files are generated/updated by flow-maven-plugin
-package.json
-package-lock.json
-webpack.config.js
+package*.json
+webpack*.js
 node_modules/

--- a/vaadin-tabs-flow-integration-tests/src/test/java/com/vaadin/flow/component/tabs/tests/SelectedTabIT.java
+++ b/vaadin-tabs-flow-integration-tests/src/test/java/com/vaadin/flow/component/tabs/tests/SelectedTabIT.java
@@ -75,7 +75,7 @@ public class SelectedTabIT extends AbstractComponentIT {
     }
 
     @Test
-    public void selectDisabledTab_noSelectionEvent_tabIsRedisabled() {
+    public void disabledTab_enableAndClick_noSelectionEvent() {
         List<TestBenchElement> tabs = $("vaadin-tabs").first().$("vaadin-tab")
                 .all();
         TestBenchElement lastTab = tabs.get(tabs.size() - 1);
@@ -86,9 +86,6 @@ public class SelectedTabIT extends AbstractComponentIT {
         lastTab.click();
 
         assertSelectionEvent(0, null);
-
-        Assert.assertEquals(Boolean.TRUE.toString(),
-                lastTab.getAttribute("disabled"));
     }
 
     @Test // https://github.com/vaadin/vaadin-tabs-flow/issues/69

--- a/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/Tab.java
+++ b/vaadin-tabs-flow/src/main/java/com/vaadin/flow/component/tabs/Tab.java
@@ -124,35 +124,6 @@ public class Tab extends GeneratedVaadinTab<Tab> implements HasComponents {
         }
     }
 
-    /**
-     * <p>
-     * If {@code false}, the user cannot interact with this element.
-     * </p>
-     *
-     * @param enabled
-     *            the boolean value to set
-     */
-    @Override
-    public void setEnabled(boolean enabled) {
-        setDisabled(!enabled);
-    }
-
-    /**
-     * <p>
-     * If {@code false}, the user cannot interact with this element.
-     * <p>
-     * This property is not synchronized automatically from the client side, so
-     * the returned value may not be the same as in client side.
-     * </p>
-     *
-     * @return the negation of {@code disabled} property value from the
-     *         webcomponent
-     */
-    @Override
-    public boolean isEnabled() {
-        return !isDisabledBoolean();
-    }
-
     @Override
     public void setSelected(boolean selected) {
         super.setSelected(selected);


### PR DESCRIPTION
As described in HasEnabled https://github.com/vaadin/flow/blob/603a7d62ca7d02fb3f515e284c99fb9333862042/flow-server/src/main/java/com/vaadin/flow/component/HasEnabled.java#L75-L79
Implementation for `setEnabled` and `isEnabled` should be inherited and not overriden to avoid security issues

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-tabs-flow/119)
<!-- Reviewable:end -->
